### PR TITLE
Fix wrong secret references

### DIFF
--- a/human-connection/deployment-backend.yaml
+++ b/human-connection/deployment-backend.yaml
@@ -51,7 +51,7 @@
           - name: JWT_SECRET
             valueFrom:
               secretKeyRef:
-                name: secret
+                name: human-connection
                 key: JWT_SECRET
                 optional: false
           - name: NEO4J_URI

--- a/human-connection/deployment-web.yaml
+++ b/human-connection/deployment-web.yaml
@@ -36,7 +36,7 @@ spec:
         - name: JWT_SECRET
           valueFrom:
             secretKeyRef:
-              name: secret
+              name: human-connection
               key: JWT_SECRET
               optional: false
         image: humanconnection/nitro-web:latest


### PR DESCRIPTION
The configs still referenced the secret config with name "secret" but it was renamed to "human-connection" so the initialization failed.