### PR TITLE
Fix endless loop

### DIFF
--- a/human-connection/configmap.yaml
+++ b/human-connection/configmap.yaml
@@ -3,7 +3,7 @@
   kind: ConfigMap
   data:
     GRAPHQL_PORT: "4000"
-    GRAPHQL_URI: "https://nitro-staging.human-connection.org/api"
+    GRAPHQL_URI: http://nitro-backend.human-connection:4000
     MOCK: "false"
     NEO4J_URI: "bolt://nitro-neo4j.human-connection:7687"
     NEO4J_USER: "neo4j"


### PR DESCRIPTION
Nitro-web was proxying to its own proxy endpoint.

cc @appinteractive

`nitro-backend.human-connection` is the DNS name of the `nitro-backend` service within the `human-connection` namespace.
![Screenshot (39)](https://user-images.githubusercontent.com/2110676/54571049-47a55e80-49e1-11e9-9a7a-3fc69da7f1d4.png)

